### PR TITLE
feat: use "patch" in update function and add deleteMany

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": false
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,19 @@ export const dataProvider = (client: SanityClient): DataProvider => {
         data: response as any
       }
     },
+
+    async deleteMany({ ids, resource, meta }) {
+      const idsStr = ids.map((id) => `"${id}"`).join(", ");
+      const { query } = q(
+          `*[_id in [${idsStr}]]${generateSelect(meta?.fields)}`,
+      ).filterByType(resource);
+
+      const response = await client.delete({ query });
+
+      return {
+          data: response as any,
+      }
+    },
     
     getApiUrl(): string {
       throw Error("Not implemented on refine-sanity data provider.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,14 @@ export const dataProvider = (client: SanityClient): DataProvider => {
       }
     },
 
-    getApiUrl(): string {
-      throw Error("Not implemented on refine-sanity data provider.");
-    },
     async create({ resource, variables }: Parameters<DataProvider['create']>[0]) {
-      const response = await client.create({
+      const response = await client.create(
+      {
         _type: resource,
         ...(variables as any)
+      },
+      {
+        autoGenerateArrayKeys: true
       });
       return {
         data: {
@@ -68,17 +69,19 @@ export const dataProvider = (client: SanityClient): DataProvider => {
       }
     },
 
-    async update({ resource, id, variables }: Parameters<DataProvider['update']>[0]) {
-      const response = await client.createOrReplace({
-        _type: resource,
-        _id: id,
-        ...(variables as any)
-      });
+    async update({ id, variables }: Parameters<DataProvider['update']>[0]) {
+      const response = await client
+        .patch(id as string)
+        .set({
+          _id: id,
+          ...(variables as any),
+        })
+        .commit({ autoGenerateArrayKeys: true });
       return {
         data: {
           ...response,
-          id: response._id
-        } as any
+          id: response._id,
+        } as any,
       }
     },
 
@@ -87,7 +90,11 @@ export const dataProvider = (client: SanityClient): DataProvider => {
       return {
         data: response as any
       }
-    }
+    },
+    
+    getApiUrl(): string {
+      throw Error("Not implemented on refine-sanity data provider.");
+    },
   };
 }
 export default dataProvider;

--- a/src/utils/generateFilter.ts
+++ b/src/utils/generateFilter.ts
@@ -26,16 +26,24 @@ const mapOperator = (operator: CrudOperators) => {
 }
 const negativeFilters = ["nin", "ncontains"];
 export const generateFilter = (filters?: CrudFilters) => {
-    const queryFilters = filters?.map((filter) => {
-    if ("field" in filter) {
-        const { field, operator, value } = filter;
-        const mappedOperator = mapOperator(operator);
-        const isNegative = negativeFilters.includes(operator);
-        const filterStr = `${field} ${mappedOperator} "${value}"`;
-        return isNegative ? `!(${filterStr})` : filterStr;
-    }
-    return undefined;
-    }).filter(v => v);
-
+    const queryFilters = filters
+      ?.map((filter) => {
+        if (Array.isArray(filter?.value) && filter.value?.length === 0) {
+          return undefined;
+        }
+  
+        if ("field" in filter) {
+          const { field, operator, value } = filter;
+          const mappedOperator = mapOperator(operator);
+          const isNegative = negativeFilters.includes(operator);
+          const filterStr = `${field} ${mappedOperator} "${value}"`;
+  
+          return isNegative ? `!(${filterStr})` : filterStr;
+        }
+        return undefined;
+      })
+      .filter((v) => v);
+  
     return queryFilters?.join(" && ");
-};
+  };
+  


### PR DESCRIPTION
fixed: when `createOrReplace` is used, `reference` values do not change. Because of that, `patch` is used in `dataProvider.update`.

fixed: `array` values need `_key` in Sanity. `autoGenerateArrayKeys` added.

feat: `deleteMany` added.

fixed: Empty array values removed from filters